### PR TITLE
#R2-1 Split Commands

### DIFF
--- a/CommandContext.cs
+++ b/CommandContext.cs
@@ -10,11 +10,11 @@ namespace Producer
         }
     }
 
-    class ConsumerCommand : IStrategy
+    class ConsumerCommand(SimpleProducer producer) : IStrategy
     {
         async public Task<dynamic> Run()
         {
-            await Task.Delay(1);
+            await producer.Publish("hello");
 
             return "Consumer command started";
         }

--- a/CommandContext.cs
+++ b/CommandContext.cs
@@ -1,0 +1,35 @@
+namespace Producer
+{
+    internal class CommandContext(IStrategy Command)
+    {
+        private IStrategy _strategy { set; get; }
+
+        public dynamic RunCommand()
+        {
+            return _strategy.Run();
+        }
+    }
+
+    class ConsumerCommand : IStrategy
+    {
+        public dynamic Run()
+        {
+            Console.WriteLine("Yo");
+            return "asdasd";
+        }
+    }
+
+    class ProducerCommand : IStrategy
+    {
+        public dynamic Run()
+        {
+            Console.WriteLine("Yo");
+            return "asdasd";
+        }
+    }
+
+    public interface IStrategy
+    {
+        dynamic Run();
+    }
+}

--- a/CommandContext.cs
+++ b/CommandContext.cs
@@ -1,35 +1,39 @@
 namespace Producer
 {
-    internal class CommandContext(IStrategy Command)
+    internal class CommandContext(IStrategy strategy)
     {
-        private IStrategy _strategy { set; get; }
+        private IStrategy Strategy { set; get; } = strategy;
 
-        public dynamic RunCommand()
+        async public Task<dynamic> RunCommand()
         {
-            return _strategy.Run();
+            return await Strategy.Run();
         }
     }
 
     class ConsumerCommand : IStrategy
     {
-        public dynamic Run()
+        async public Task<dynamic> Run()
         {
-            Console.WriteLine("Yo");
-            return "asdasd";
+            await Task.Delay(1);
+
+            return "Consumer command started";
         }
     }
 
     class ProducerCommand : IStrategy
     {
-        public dynamic Run()
+        async public Task<dynamic> Run()
         {
-            Console.WriteLine("Yo");
-            return "asdasd";
+            await Task.Delay(1);
+
+            return "Producer command started";
         }
+
+
     }
 
     public interface IStrategy
     {
-        dynamic Run();
+        abstract public Task<dynamic> Run();
     }
 }

--- a/DotEnv.cs
+++ b/DotEnv.cs
@@ -1,6 +1,5 @@
 namespace Producer
 {
-
     internal class DotEnv
     {
         public static void Load(string filePath)

--- a/DotEnv.cs
+++ b/DotEnv.cs
@@ -1,30 +1,31 @@
-namespace Producer;
-
-internal class DotEnv
+namespace Producer
 {
-    public static void Load(string filePath)
+
+    internal class DotEnv
     {
-        if (!File.Exists(filePath))
-            return;
-
-        foreach (var line in File.ReadAllLines(filePath))
+        public static void Load(string filePath)
         {
-            var parts = line.Split(
-                '=',
-                StringSplitOptions.RemoveEmptyEntries);
+            if (!File.Exists(filePath))
+                return;
 
-            if (parts.Length != 2)
-                continue;
+            foreach (var line in File.ReadAllLines(filePath))
+            {
+                var parts = line.Split(
+                    '=',
+                    StringSplitOptions.RemoveEmptyEntries);
 
-            Environment.SetEnvironmentVariable(parts[0], parts[1]);
+                if (parts.Length != 2)
+                    continue;
+
+                Environment.SetEnvironmentVariable(parts[0], parts[1]);
+            }
+        }
+
+        public static string GetEnv(string key)
+        {
+            string value = Environment.GetEnvironmentVariable(key) ?? "";
+
+            return value;
         }
     }
-
-    public static string GetEnv(string key)
-    {
-        string value = Environment.GetEnvironmentVariable(key) ?? "";
-
-        return value;
-    }
-
 }

--- a/IProducer.cs
+++ b/IProducer.cs
@@ -1,6 +1,8 @@
-namespace Producer;
-
-public interface IProducer
+namespace Producer
 {
-    public Task<long> Publish(string message);
+
+    public interface IProducer
+    {
+        public Task<long> Publish(string message);
+    }
 }

--- a/Producer.cs
+++ b/Producer.cs
@@ -1,18 +1,20 @@
-namespace Producer;
 using System.Text.Json;
 using StackExchange.Redis;
 
-public class SimpleProducer(RedisClient redisClient, string channel) : IProducer
+namespace Producer
 {
-    public async Task<long> Publish(string message)
+    public class SimpleProducer(RedisClient redisClient, string channel) : IProducer
     {
-        return await redisClient
-        .GetSubscriber()
-        .PublishAsync(
-            channel,
-             JsonSerializer.Serialize(message),
-             CommandFlags.FireAndForget
-             );
+        public async Task<long> Publish(string message)
+        {
+            return await redisClient
+            .GetSubscriber()
+            .PublishAsync(
+                channel,
+                 JsonSerializer.Serialize(message),
+                 CommandFlags.FireAndForget
+                 );
 
+        }
     }
 }

--- a/Program.cs
+++ b/Program.cs
@@ -1,54 +1,60 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using CommandLine;
 
-namespace Producer;
-
-public class Program
+namespace Producer
 {
-    public class Options
+    public class Program
     {
-        [Option('m', "message", Required = false, HelpText = "Message.")]
-        public required string Message { get; set; }
-        [Option('c', "command", Required = true, HelpText = "Command.", Default = "Consumer")]
-        public required string Command { get; set; }
-    }
-    static ServiceProvider InitContainer()
-    {
-        ServiceCollection services = new();
-        services.AddSingleton<RedisClient>(new RedisClient(DotEnv.GetEnv("REDIS_DSN")));
-        services.AddSingleton<ConsumerCommand, ConsumerCommand>();
-        services.AddSingleton<ProducerCommand, ProducerCommand>();
-        services.AddSingleton<SimpleProducer>((IServiceProvider provider) => new SimpleProducer(provider.GetService<RedisClient>() ?? throw new Exception("bla"), DotEnv.GetEnv("PRODUCER_CHANNEL")));
-        ServiceProvider provider = services.BuildServiceProvider();
-
-        return provider;
-    }
-
-    static async Task Main(string[] args)
-    {
-        DotEnv.Load(".env");
-        string message = "";
-        string command = "Consumer";
-        ParserResult<Options> options = Parser.Default.ParseArguments<Options>(args)
-                   .WithParsed(options =>
-                   {
-                       message = options.Message;
-                       command = options.Command;
-                   });
-
-        Dictionary<string, Type> commandMap = new()
+        public class Options
         {
-            ["Producer"] = typeof(ProducerCommand),
-            ["Consumer"] = typeof(ConsumerCommand),
+            [Option('m', "message", Required = false, HelpText = "Message.")]
+            public required string Message { get; set; }
+            [Option('c', "command", Required = true, HelpText = "Command.", Default = "Consumer")]
+            public required string Command { get; set; }
+        }
+        static ServiceProvider InitContainer()
+        {
+            ServiceCollection services = new();
+            services.AddSingleton<RedisClient>(new RedisClient(DotEnv.GetEnv("REDIS_DSN")));
+            services.AddSingleton<SimpleProducer>((IServiceProvider provider) => new SimpleProducer(provider.GetRequiredService<RedisClient>(), DotEnv.GetEnv("PRODUCER_CHANNEL")));
+            services.AddSingleton<ConsumerCommand>((IServiceProvider provider) => new ConsumerCommand(provider.GetRequiredService<SimpleProducer>()));
+            services.AddSingleton<ProducerCommand, ProducerCommand>();
+            ServiceProvider provider = services.BuildServiceProvider();
 
-        };
+            return provider;
+        }
 
-        using ServiceProvider provider = InitContainer();
+        static async Task Main(string[] args)
+        {
+            DotEnv.Load(".env");
+            string message = "";
+            string command = "";
+            ParserResult<Options> options = Parser.Default.ParseArguments<Options>(args)
+                       .WithParsed(options =>
+                       {
+                           message = options.Message;
+                           command = options.Command;
+                       });
 
-        IStrategy Command = (IStrategy)provider.GetRequiredService(commandMap[command]);
-        CommandContext Context = new(Command);
-        var result = await Context.RunCommand();
+            Dictionary<string, Type> commandMap = new()
+            {
+                ["producer"] = typeof(ProducerCommand),
+                ["consumer"] = typeof(ConsumerCommand),
 
-        Console.WriteLine(result);
+            };
+
+            if (commandMap.Keys.ToList().Contains(command) == false)
+            {
+                Console.Error.WriteLine("Command '{0}' not registered", command);
+                return;
+            }
+
+            using ServiceProvider provider = InitContainer();
+            IStrategy Command = (IStrategy)provider.GetRequiredService(commandMap[command]);
+            CommandContext CommandContext = new(Command);
+            var result = await CommandContext.RunCommand();
+
+            Console.WriteLine(result);
+        }
     }
 }

--- a/RedisClient.cs
+++ b/RedisClient.cs
@@ -1,14 +1,16 @@
 
 using StackExchange.Redis;
 
-namespace Producer;
-
-public class RedisClient(string DSN)
+namespace Producer
 {
-    private readonly ConnectionMultiplexer _connection = ConnectionMultiplexer.Connect(DSN);
 
-    public ISubscriber GetSubscriber()
+    public class RedisClient(string DSN)
     {
-        return _connection.GetSubscriber();
+        private readonly ConnectionMultiplexer _connection = ConnectionMultiplexer.Connect(DSN);
+
+        public ISubscriber GetSubscriber()
+        {
+            return _connection.GetSubscriber();
+        }
     }
 }

--- a/RedisClient.cs
+++ b/RedisClient.cs
@@ -1,9 +1,7 @@
-
 using StackExchange.Redis;
 
 namespace Producer
 {
-
     public class RedisClient(string DSN)
     {
         private readonly ConnectionMultiplexer _connection = ConnectionMultiplexer.Connect(DSN);


### PR DESCRIPTION
## What?
{TASK-R2-1}
CLI commands were divided into separate classes: Consumer and Producer.
DI for consumer command updated.
Implemented args message (--m message) and command (--c command).
Implemented validation rule for command argument
Removed blank lines
Fixed namespace position
## Why?
These changes allow you to use the multitasking CLI application.
## How?
The list of available commands implemented + added CommandContext to run commands.
## Testing?
No tests.


